### PR TITLE
Use qt4 when building when qt5 also exist on system

### DIFF
--- a/src/solvers/gecode/presolver.mk
+++ b/src/solvers/gecode/presolver.mk
@@ -76,7 +76,7 @@ $(PRESOLVERBIN): $(PRESOLVERGENMAKEFILE)
 	fi; \
 
 $(PRESOLVERGENMAKEFILE): $(PRESOLVERPROJECT) $(PRESOLVERSRC)
-	qmake TARGET="gecode-presolver" CONFIG+="$(UNISON_SOLVER_CONFIG)" -o $@ $<
+	qmake-qt4 TARGET="gecode-presolver" CONFIG+="$(UNISON_SOLVER_CONFIG)" -o $@ $<
 
 clean-presolver:
 	rm -f $(PRESOLVERDIR)/*.o $(PRESOLVERDIR)/*~ $(PRESOLVERGENMAKEFILE) $(PRESOLVERDIR)/moc_*.cpp

--- a/src/solvers/gecode/solver.mk
+++ b/src/solvers/gecode/solver.mk
@@ -79,14 +79,14 @@ $(SOLVERBIN): $(GENMAKEFILE)
 	fi; \
 
 $(GENMAKEFILE): $(SOLVERPROJECT) $(SOLVERSRC)
-	qmake TARGET="gecode-solver" CONFIG+="$(UNISON_SOLVER_CONFIG)" -o $@ $<
+	qmake-qt4 TARGET="gecode-solver" CONFIG+="$(UNISON_SOLVER_CONFIG)" -o $@ $<
 
 $(SOLVERSTATICBIN): $(GENMAKEFILESTATIC)
 	$(MAKE) -C $(SOLVERDIR) -f $(notdir $<)
 	strip --strip-debug $(SOLVERSTATICBIN)
 
 $(GENMAKEFILESTATIC): $(SOLVERPROJECT) $(SOLVERSRC)
-	qmake TARGET="gecode-solver-static" CONFIG+="static" -o $@ $<
+	qmake-qt4 TARGET="gecode-solver-static" CONFIG+="static" -o $@ $<
 
 clean-solver:
 	rm -f $(SOLVERDIR)/*.o $(SOLVERDIR)/*~ $(GENMAKEFILE) $(GENMAKEFILESTATIC) $(SOLVERDIR)/moc_*.cpp


### PR DESCRIPTION
When both qt4 and qt5 is installed on the system, building unison defaults to using qt5 due to "qmake". Using command "qmake-qt4" forces the build to use qt4 instead. The command "qmake-qt4" should exist on systems with only qt4 installed as well.  This should solve Issue #28.