### PR TITLE
Fixes in sources

### DIFF
--- a/src/solvers/gecode/branchers/value.cpp
+++ b/src/solvers/gecode/branchers/value.cpp
@@ -99,7 +99,8 @@ register_space most_effective(const Space& s, SetVar pals, global_congruence g) 
     for (register_space rs : urss) {
 
       Singleton rsA(m.input->range[rs][0], m.input->range[rs][1]);
-      NaryInter A(region, tA, rsA);
+      auto tA_ = tA;
+      NaryInter A(region, tA_, rsA);
 
       // Compute cost for g and all allocatable atom sets
       //

--- a/src/solvers/gecode/models/globalmodel.cpp
+++ b/src/solvers/gecode/models/globalmodel.cpp
@@ -170,9 +170,10 @@ double GlobalModel::coalescing_chances(operand p, RangeListIter & A) const {
   // Compute common atoms between A and the home register space of q
   register_space rsq = input->home[q];
   Singleton Aq(input->range[rsq][0], input->range[rsq][1]);
-  Inter<RangeListIter, Singleton> Ahrs(A, Aq);
+  auto A_ = A;
+  Inter<RangeListIter, Singleton> Ahrs(A_, Aq);
   // Return percentage of A atoms in the home register space of q
-  double chances = (double)range_size(Ahrs) / (double)range_size(A);
+  double chances = (double)range_size(Ahrs) / (double)range_size(A_);
   return chances;
 }
 

--- a/src/solvers/gecode/models/model.cpp
+++ b/src/solvers/gecode/models/model.cpp
@@ -399,7 +399,7 @@ double Model::pressure_balance(operation o) const {
     for (IntVarValues ii(i(o)); ii(); ++ii) {
       register_class rc = input->rclass[o][ii.val()][pi];
       double pr = pressure(p, rc);
-      if (p > maxp) maxp = pr;
+      if (pr > maxp) maxp = pr;
     }
     if (input->use[p])
       in_pressure += maxp;

--- a/src/solvers/gecode/models/model.cpp
+++ b/src/solvers/gecode/models/model.cpp
@@ -566,7 +566,7 @@ void Model::post_live_start_definition(block b) {
   // The live range of a temporary starts at the issue cycle of its definer:
 
   for (temporary t : input->tmp[b])
-    constraint(ls(t) == c(input->oper[input->definer[t]]));
+    constraint(ls(t) == c(input->def_opr[t]));
 
 }
 

--- a/src/solvers/gecode/models/model.cpp
+++ b/src/solvers/gecode/models/model.cpp
@@ -336,7 +336,8 @@ saturation_likelihood(block b, pair<int,int> C, RangeListIter & A) const {
       IntVarRanges tregs(r(t));
       Region r1;
       RangeListIter tAtoms = extend(r1, tregs, w);
-      Inter<RangeListIter, RangeListIter> At(A, tAtoms);
+      auto A_ = A;
+      Inter<RangeListIter, RangeListIter> At(A_, tAtoms);
       double t_in_A = (double)range_size(At) / (double)range_size(tAtoms);
       if (t_in_A > numeric_limits<double>::epsilon()) in_A[t] = t_in_A;
       totalw += w;

--- a/src/solvers/gecode/presolver/diff_temps.cpp
+++ b/src/solvers/gecode/presolver/diff_temps.cpp
@@ -94,6 +94,8 @@ void diff_temps(Parameters& input) {
                 operand p  = op->second;
                 operand p1 = o1p1->second;
 
+		// Different operands of one instruction can use same tmp
+		if (input.type[o] != OUT && o == o1) continue;
                 // build (o,o')
                 pair<operation, operation> oo1 = make_pair(o, o1);
 

--- a/src/solvers/gecode/procedures/globalprocedures.cpp
+++ b/src/solvers/gecode/procedures/globalprocedures.cpp
@@ -595,12 +595,12 @@ SolverResult shave_local_costs(GlobalModel * base) {
         Gecode::SpaceStatus ss = base->status();
         stats.fail++;
         if (ss == SS_FAILED) {
-          delete base;
           if (base->options->verbose()) {
             cerr << global()
                  << "failed due to cost shaving: f(b" << b << ") <= "
                  << cost << endl;
           }
+	  delete base;
           return SHAVING_FAILURE;
         }
         break;


### PR DESCRIPTION
This patch fix:

- Variable for pressure comparison;
- Use of iterators for register spaces. After intersection iterator will be
 empty due to use by reference. It will invalid next try of register space;
- Use after free case;
- Allow to use same temporary for different operands in one operation.