### PR TITLE
Draft superscalar support

### DIFF
--- a/src/solvers/gecode/models/completemodel.cpp
+++ b/src/solvers/gecode/models/completemodel.cpp
@@ -84,6 +84,7 @@ CompleteModel::CompleteModel(Parameters * p_input, ModelOptions * p_options,
   v_r   = int_var_array(T().size(), -1, input->RA.size() - 1);
   v_i   = int_var_array(O().size(), 0, input->I.size() - 1);
   v_c   = int_var_array(O().size(), 0, max_of(input->maxc));
+  v_ff  = int_var_array(O().size(), 0, W * max_of(input->maxc));
   if (!P().empty()) {
     v_y = int_var_array(P().size(), 0, input->T.size() - 1);
   }
@@ -91,9 +92,13 @@ CompleteModel::CompleteModel(Parameters * p_input, ModelOptions * p_options,
   v_ry  = int_var_array(P().size(), -1, input->RA.size() - 1);
   v_a   = bool_var_array(O().size(), 0, 1);
   v_ls  = int_var_array(T().size(), 0, max_of(input->maxc));
+  v_ls_ff = int_var_array(T().size(), 0, W * max_of(input->maxc));
   v_ld  = int_var_array(T().size(), 0, max_of(input->maxc));
+  v_ld_ff = int_var_array(T().size(), 0, W * max_of(input->maxc));
   v_le  = int_var_array(T().size(), 0,
                         max_of(input->maxc) + maybe_max_of(0, input->minlive));
+  v_le_ff = int_var_array(T().size(), 0,
+                          W * (max_of(input->maxc) + maybe_max_of(0, input->minlive)));
   v_al  = bool_var_array(T().size() * input->RS.size(), 0, 1);
   v_u   = bool_var_array(input->nu, 0, 1);
   v_us  = int_var_array(T().size(), 0, O().size());
@@ -370,6 +375,10 @@ string CompleteModel::solution_to_json() const {
   for (operation o : input->O)
     cs.push_back(a(o).val() ? c(o).val() : -1);
 
+  vector<int> ffs;
+  for (operation o : input->O)
+    ffs.push_back(a(o).val() ? ff(o).val() : -1);
+
   vector<temporary> ys;
   for (operand p : input->P)
     ys.push_back(input->temps[p][y(p).val()]);
@@ -378,6 +387,7 @@ string CompleteModel::solution_to_json() const {
   pOs << "\"registers\":" << to_json(rs) << ",";
   pOs << "\"instructions\":" << to_json(is) << ",";
   pOs << "\"cycles\":" << to_json(cs) << ",";
+  pOs << "\"fetches\":" << to_json(ffs) << ",";
   pOs << "\"temporaries\":" << to_json(ys);
   pOs << "}";
 

--- a/src/solvers/gecode/models/globalmodel.cpp
+++ b/src/solvers/gecode/models/globalmodel.cpp
@@ -709,6 +709,8 @@ void GlobalModel::post_complete_branchers(unsigned int s) {
   branch(*this, v_c, INT_VAR_NONE(), INT_VAL_MIN(),
          &schedulable, &print_global_cycle_decision);
 
+  branch(*this, v_ff, INT_VAR_NONE(), INT_VAL_MIN());
+
   branch(*this, v_r, INT_VAR_NONE(), INT_VAL_RND(r),
          &global_assignable, &print_global_register_decision);
 
@@ -786,8 +788,10 @@ void GlobalModel::apply_solution(LocalModel * ls) {
     constraint(i(o) == ls->i(o));
 
   for (operation o : input->ops[b])
-    if (!ls->is_inactive(o))
+    if (!ls->is_inactive(o)) {
       constraint(c(o) == ls->c(o));
+      constraint(ff(o) == ls->ff(o));
+    }
 
   for (operand p : input->ope[b])
     constraint(y(p) == ls->y(p));

--- a/src/solvers/gecode/models/simplemodel.cpp
+++ b/src/solvers/gecode/models/simplemodel.cpp
@@ -78,4 +78,5 @@ void SimpleModel::post_trivial_branchers(void) {
   branch(*this, v_r, INT_VAR_NONE(), INT_VAL_MIN());
   // TODO: do not assign cycles to inactive operations
   branch(*this, v_c, INT_VAR_NONE(), INT_VAL_MIN());
+  branch(*this, v_ff, INT_VAR_NONE(), INT_VAL_MIN());
 }

--- a/src/unison/src/Unison/Tools/Export.hs
+++ b/src/unison/src/Unison/Tools/Export.hs
@@ -86,12 +86,14 @@ parseSolution json =
                        Nothing -> error ("error parsing JSON input")
                        Just (Object s) -> s
         cycles       = sol HM.! "cycles"
+        fetches      = sol HM.! "fetches"
         instructions = sol HM.! "instructions"
         registers    = sol HM.! "registers"
         temporaries  = sol HM.! "temporaries"
         has_sol      = sol HM.! "has_solution"
     in if (solutionFromJson has_sol :: Bool) then
            Just (solutionFromJson cycles       :: [Integer],
+                 solutionFromJson fetches      :: [Integer],
                  solutionFromJson instructions :: [InstructionId],
                  solutionFromJson registers    :: [RegisterAtom],
                  solutionFromJson temporaries  :: [TemporaryId])
@@ -102,7 +104,7 @@ solutionFromJson object =
       Error e -> error ("error converting JSON input:\n" ++ show e)
       Success s -> s
 
-uniTransformations (cycles, instructions, registers, temporaries)
+uniTransformations (cycles, fetches, instructions, registers, temporaries)
                                (removeReds, keepNops, tight) =
     [(assignRegisters tight registers, "assignRegisters", True),
      (selectTemporaries temporaries, "selectTemporaries", True),
@@ -113,7 +115,7 @@ uniTransformations (cycles, instructions, registers, temporaries)
      (runTargetTransforms ExportPostOffs, "runTargetTransforms", True),
      (lowerFrameSize, "lowerFrameSize", True),
      (directFrame, "directFrame", True),
-     (bundleOperations cycles, "bundleOperations", True),
+     (bundleOperations cycles fetches, "bundleOperations", True),
      (removeRedundancies, "removeRedundancies", removeReds),
      (runTargetTransforms ExportPreLow, "runTargetTransforms", True),
      (lowerFrameIndices, "lowerFrameIndices", True),

--- a/src/unison/src/Unison/Tools/Export/BundleOperations.hs
+++ b/src/unison/src/Unison/Tools/Export/BundleOperations.hs
@@ -13,22 +13,25 @@ module Unison.Tools.Export.BundleOperations (bundleOperations) where
 
 import qualified Data.Map as M
 import qualified Data.Set as S
+import qualified Data.List as L
 
 import Unison
 
-bundleOperations cycles f @ Function {fCode = code} _ =
+bundleOperations cycles fetches f @ Function {fCode = code} _ =
     let i2c   = M.fromList (zip (flatten code) cycles)
-        bcode = map (toBundleBlock i2c) code
+        i2f   = M.fromList (zip (flatten code) fetches)
+        bcode = map (toBundleBlock i2c i2f) code
     in f {fCode = bcode}
 
-toBundleBlock i2c b @ Block {bCode = code} =
+toBundleBlock i2c i2f b @ Block {bCode = code} =
   let code' = filter isActive code
       is    = S.fromList code'
       i2c'  = M.filterWithKey (\i _ -> S.member i is) i2c
       c2is  = foldr mapAppend M.empty [(c, [i]) | (i, c) <- M.toList i2c']
       cs    = zip [0 .. fst (M.findMax c2is)] (repeat [])
       c2is' = M.toList $ foldr mapAppend c2is cs
-      bcode = map (Bundle . snd) c2is'
+      sortByFetch is = L.sortBy (\i1 i2 -> compare (i2f M.! i1) (i2f M.! i2)) is
+      bcode = map (Bundle . sortByFetch . snd) c2is'
   in b {bCode = bcode}
 
 isActive o | oInstructions o == [mkNullInstruction] = False


### PR DESCRIPTION
This draft PR illustrates the possibility of adding support for superscalar architectures in Unison.

It's based on the following suggestion from Roberto:
```
Here is my idea to model out-of-order execution in a more accurate and                                                                                                                                      
(hopefully) scalable way. The key idea is to mimic the OoO
architecture by decoupling the order in which instructions are fetched
and their execution schedule in the constraint model. Currently, the
model uses a single set of variables issue(o) (in the notation of the
TOPLAS paper [1]) to capture both fetching and executing. My proposal
would be to decouple this into two sets of variables, say f(o) and
e(o), giving the fetch order and (estimated) execution cycle of each
operation o.

Fetch order variables. These variables model the sequential order in
which operations are presented to the OoO processor. They define a
total ordering among all operations in a basic block; would determine
the live ranges; and, by extension, would be involved in all register
allocation constraints (see Table 7 in [1]).
There may be "holes" in the f(o) variables but that shouldn't be a
problem from the modeling perspective.

Execution cycle variables. These variables model an estimation of the
actual schedule in which operations are executed. They define a
partial ordering among all operations in a basic block, since as many
operations as the issue width (W) of the processor can be scheduled in
parallel. They would be involved in all instruction scheduling
constraints (resource usage, etc.).

These two sets of variables would have to be linked ("channeled" in
constraint programming speak) so that all operations estimated to be
executed in parallel (by the e(o) variables) are ordered contiguously
according to the f(o) variables. This could be achieved, I think, by
the following constraints:

e(o) * W <= f(o) < (e(o) + 1) * W     for all o in O_b, for all b in B
alldifferent({f(o) : o in O_b})    for all b in B

The appeal with this model is that it avoids introducing a quadratic
number of variables or constraints, which tends to affect scalability
severely as you noted in your email.

I also created an example of this model extension using the program
from Fig. 15 in [1] and assuming W = 2, see attachment.

While the idea is, conceptually, fairly simple, extending the Unison
implementation would probably be non-trivial and require serious
constraint programming expertise.
```
![20230218_172429](https://github.com/unison-code/unison/assets/1101391/22596365-4f58-4fe2-b520-011f2737bb7c)

The code most likely has many deficiencies so feedback and suggestions are very welcome.